### PR TITLE
Fix base url for deployed site

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseURL      = ''
+baseURL      = '/'
 languageCode = 'en-us'
 title        = 'Jeffrey Xiao'
 theme        = "hello-friend-ng"


### PR DESCRIPTION
Tags do not work on the deployed site, but do on local.